### PR TITLE
Implement local scheduler service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tqdm
 prometheus-clien
 redis
 minio
+schedule==1.*

--- a/src/local/scheduler.py
+++ b/src/local/scheduler.py
@@ -1,0 +1,17 @@
+import schedule
+import time
+from src.infra.lambdas.RSSQueueFiller.lambda.lambda_function import handler
+
+
+def run_queue_filler():
+    """Invoke the queue filler lambda logic."""
+    handler(None, None)
+
+
+schedule.every(4).hours.do(run_queue_filler)
+
+
+if __name__ == "__main__":
+    while True:
+        schedule.run_pending()
+        time.sleep(1)


### PR DESCRIPTION
## Summary
- add scheduler service to call the RSS queue filler logic locally
- include empty package initialization for local scheduler
- add `schedule` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d91b3d8a4832d81b6f61920fcd6f7