### PR TITLE
Add local launch option and env template

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -4,17 +4,65 @@ import json
 import boto3
 from dotenv import load_dotenv
 import logging
+import argparse
+import subprocess
 from src.infra.lambdas.RSSQueueFiller.deploy_sqs_filler_lambda import deploy_sqs_filler
 
 from src.utils.check_env import check_env
 
+
+def check_local_env() -> None:
+    """Ensure required environment variables for local mode are set."""
+    required_vars = [
+        "MONGODB_URL",
+        "MONGODB_DB_NAME",
+        "MONGODB_COLLECTION_NAME",
+        "REDIS_URL",
+        "REDIS_QUEUE_NAME",
+        "MINIO_ENDPOINT",
+        "MINIO_ACCESS_KEY",
+        "MINIO_SECRET_KEY",
+        "MINIO_BUCKET",
+    ]
+
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(
+            f"Missing required environment variables for local mode: {', '.join(missing)}"
+        )
+
+
+def start_docker_containers() -> None:
+    """Start required Docker containers for local development."""
+    try:
+        subprocess.check_call(["docker-compose", "up", "-d"])
+    except FileNotFoundError:
+        # fallback to `docker compose` if docker-compose command not found
+        subprocess.check_call(["docker", "compose", "up", "-d"])
+    except Exception as exc:
+        logging.error(f"Failed to start Docker containers: {exc}")
+        raise
+
+
 print("🗞️  💵 ⚖️  IngestRSS⚖️  💵 🗞️".center(100, "-"))
 
+parser = argparse.ArgumentParser(description="Launch IngestRSS")
+parser.add_argument(
+    "--local",
+    action="store_true",
+    help="Run locally using Docker instead of deploying to AWS",
+)
+args = parser.parse_args()
+
 load_dotenv(override=True)
-check_env()
+
+if args.local:
+    check_local_env()
+else:
+    check_env()
 
 # Set up logging
-logging.basicConfig(level=os.getenv('LOG_LEVEL'))
+logging.basicConfig(level=os.getenv("LOG_LEVEL"))
 
 lambda_client = boto3.client("lambda")
 
@@ -27,21 +75,25 @@ from src.infra.lambdas.RSSFeedProcessorLambda.deploy_rss_feed_lambda import depl
 from src.infra.lambdas.lambda_utils.update_lambda_env_vars import update_env_vars
 from src.feed_management.upload_rss_feeds import upload_rss_feeds
 
-def main():
-    # Deploy infrastructure
-    deploy_infrastructure() 
-    logging.info("Finished Deploying Infrastructure")
-   
-    # Deploy Lambda function
-    deploy_lambda()
-    logging.info("Finished Deploying Lambda")
 
-    deploy_sqs_filler()
-    logging.info("Finished Deploying Queue Filler Lambda")
+def main(local: bool = False) -> None:
+    if local:
+        start_docker_containers()
+    else:
+        # Deploy infrastructure
+        deploy_infrastructure()
+        logging.info("Finished Deploying Infrastructure")
 
-    # Update Lambda environment variables
-    update_env_vars(os.getenv("LAMBDA_FUNCTION_NAME"))
-    print("Finished Environment Variable Updates")
+        # Deploy Lambda function
+        deploy_lambda()
+        logging.info("Finished Deploying Lambda")
+
+        deploy_sqs_filler()
+        logging.info("Finished Deploying Queue Filler Lambda")
+
+        # Update Lambda environment variables
+        update_env_vars(os.getenv("LAMBDA_FUNCTION_NAME"))
+        print("Finished Environment Variable Updates")
     
     # Upload RSS feeds
     rss_feeds_file = os.path.join(current_dir, "rss_feeds.json")
@@ -61,4 +113,4 @@ def main():
     print("RSS Feed Processor launched successfully!")
 
 if __name__ == "__main__":
-    main()
+    main(args.local)

--- a/local.env.template
+++ b/local.env.template
@@ -1,0 +1,25 @@
+# Local environment configuration for IngestRSS
+
+# Redis configuration
+REDIS_URL=redis://localhost:6379
+REDIS_QUEUE_NAME=rss-feed-queue
+
+# MinIO configuration
+MINIO_ENDPOINT=***
+MINIO_ACCESS_KEY=***
+MINIO_SECRET_KEY=***
+MINIO_BUCKET=***
+
+# MongoDB settings
+MONGODB_URL=mongodb://localhost:27017
+MONGODB_DB_NAME=ingestrss
+MONGODB_COLLECTION_NAME=rss_feeds
+
+# Logging Configuration
+LOG_LEVEL=INFO
+
+# Other Application Settings
+APP_NAME=RSS Feed Processor
+VERSION=1.0.0
+
+STORAGE_STRATEGY=s3


### PR DESCRIPTION
## Summary
- support a `--local` flag in `launch.py` for running Docker containers
- check only local environment variables when using `--local`
- keep AWS deploy behaviour for default mode
- add `local.env.template` for running without AWS credentials

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python launch.py --help` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_683d91bc0ab0832d89a4cd4d148f7de0